### PR TITLE
fix(js): Remove redundant declaration of useKanban

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,4 @@
 const { createApp, defineComponent, nextTick } = Vue;
-const { useKanban } = window;
 
 // --- Компонент для отображения Задачи ---
 const TaskCard = defineComponent({


### PR DESCRIPTION
The `useKanban` function is loaded via a `<script>` tag in `index.html`, which adds it to the global `window` object. The `main.js` script was attempting to re-declare this function using `const { useKanban } = window;`, causing a `SyntaxError: Identifier 'useKanban' has already been declared`.

This change removes the unnecessary and erroneous redeclaration from `main.js`, resolving the error. The function remains accessible through the global scope as intended.