### PR TITLE
fix(api): Correct database query and insert errors for tasks

### DIFF
--- a/src/services/supabaseService.js
+++ b/src/services/supabaseService.js
@@ -63,8 +63,12 @@ export async function createTask(taskData, projectId) {
         return null;
     }
 
+    // Destructure to handle the column name mismatch between frontend and DB
+    const { issue_type, ...restOfTaskData } = taskData;
+
     const taskToInsert = {
-        ...taskData,
+        ...restOfTaskData,
+        issue_type_id: issue_type, // Map to the correct DB column
         project_id: projectId,
         reporter_id: user.id,
     };


### PR DESCRIPTION
This commit resolves three critical errors in the `supabaseService.js` file that prevented tasks from being fetched and created correctly.

1.  **Fix Ambiguous Relationship in `getTasks`:** The query to fetch tasks was failing because the relationship to the `profiles` table was ambiguous. The query has been updated to explicitly use the `assignee_id` for embedding the assignee's data.

2.  **Fix Incorrect Column Name (`author_id`) in `createTask`:** The `createTask` function was attempting to insert data into a non-existent `author_id` column. This has been corrected to use the proper column name from the database schema, `reporter_id`.

3.  **Fix Incorrect Column Name (`issue_type`) in `createTask`:** The function was also attempting to insert into a non-existent `issue_type` column. The code now correctly maps the `issue_type` value from the frontend to the `issue_type_id` column in the database.