### PR TITLE
The `create-project` Edge Function was failing because preflight `OPT…

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,5 +1,30 @@
-export const corsHeaders = {
-  'Access-Control-Allow-Origin': 'https://kanbancic-production.up.railway.app',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS, PUT, DELETE',
+// List of allowed origins for CORS.
+const allowedOrigins = [
+  'https://kanbancic-production.up.railway.app', // Production frontend
+  'http://localhost:5173',                      // Default Vite dev server
+  'http://localhost:3000',                      // Common alternative dev server
+];
+
+/**
+ * Utility function to handle CORS headers.
+ * It checks the request's Origin header against a list of allowed origins.
+ * @param {Request} req - The incoming request object.
+ * @returns {Object} - The appropriate CORS headers.
+ */
+export const getCorsHeaders = (req: Request) => {
+  const origin = req.headers.get('Origin');
+
+  // If the request's origin is in our list of allowed origins,
+  // set the Access-Control-Allow-Origin header to that origin.
+  // Otherwise, do not set the header, which will cause the browser's
+  // CORS check to fail, as intended.
+  const corsOrigin = origin && allowedOrigins.includes(origin)
+    ? origin
+    : '';
+
+  return {
+    'Access-Control-Allow-Origin': corsOrigin,
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+    'Access-Control-Allow-Methods': 'POST, GET, OPTIONS, PUT, DELETE',
+  };
 };

--- a/supabase/functions/create-project/index.ts
+++ b/supabase/functions/create-project/index.ts
@@ -1,6 +1,6 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { corsHeaders } from '../_shared/cors.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
 
 // Initialize Supabase client
 const supabaseUrl = Deno.env.get('SUPABASE_URL');
@@ -8,6 +8,7 @@ const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
 serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
   // Обработка preflight-запроса
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders, status: 200 });

--- a/supabase/functions/gemini-proxy/index.ts
+++ b/supabase/functions/gemini-proxy/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { getCorsHeaders } from "../_shared/cors.ts";
 
 const GEMINI_API_KEY = Deno.env.get("GEMINI_API_KEY");
 const GEMINI_API_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${GEMINI_API_KEY}`;
@@ -63,6 +63,7 @@ function parseAiResponse(text: string): object {
 }
 
 serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
   // Handle CORS preflight requests
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders, status: 200 });

--- a/supabase/functions/manage-project-members/index.ts
+++ b/supabase/functions/manage-project-members/index.ts
@@ -1,6 +1,6 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { corsHeaders } from '../_shared/cors.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
 
 // Initialize Supabase Admin Client for elevated privileges
 const supabaseAdmin = createClient(
@@ -19,6 +19,7 @@ async function getUserRole(userClient: SupabaseClient, projectId: string): Promi
 }
 
 serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders, status: 200 });
   }

--- a/supabase/functions/send-assignment-notification/index.ts
+++ b/supabase/functions/send-assignment-notification/index.ts
@@ -1,5 +1,5 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
-import { corsHeaders } from '../_shared/cors.ts';
+import { getCorsHeaders } from '../_shared/cors.ts';
 
 // A simple email sending simulation.
 // In a production environment, this would be replaced with a real email client
@@ -15,6 +15,7 @@ async function sendEmail(to: string, subject: string, body: string) {
 }
 
 serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
   // Handle CORS preflight requests.
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders, status: 200 });


### PR DESCRIPTION
…IONS` requests did not return a `200 OK` status, causing browsers to block the subsequent `POST` request due to CORS policy.

This change refactors the shared CORS handling to be more robust. A new `getCorsHeaders` function in `_shared/cors.ts` now dynamically validates the request's `Origin` against a list of allowed origins (production and local development).

All Edge Functions (`create-project`, `gemini-proxy`, `manage-project-members`, `send-assignment-notification`) have been updated to use this new dynamic CORS handling function. This ensures consistent and correct CORS behavior across the entire application and prevents similar issues in the future.