### PR TITLE
fix: resolve project creation and auth errors

### DIFF
--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -43,13 +43,22 @@ const handleSignup = async () => {
   successMessage.value = '';
   try {
     await signUp(email.value, password.value);
-    successMessage.value = 'Success! Please check your email to confirm your account.';
+    // Set success message in Russian for consistency with the UI.
+    successMessage.value = 'Регистрация прошла успешно! Пожалуйста, проверьте свою почту для подтверждения, а затем войдите.';
     logInfo('User signup successful, pending email confirmation', { email: email.value });
-    // We don't redirect immediately, as the user needs to confirm their email.
-    // A better user experience might be to show a "Check your email" page.
-    // For now, we'll just show a message.
+
+    // Redirect to the login page after a delay so the user can read the message.
+    setTimeout(() => {
+      router.push('/login');
+    }, 4000); // 4-second delay
+
   } catch (error) {
-    errorMessage.value = error.message;
+    // Provide a user-friendly error message in Russian.
+    if (error.message && error.message.includes('User already registered')) {
+      errorMessage.value = 'Пользователь с таким email уже зарегистрирован.';
+    } else {
+      errorMessage.value = `Произошла ошибка: ${error.message || 'Неизвестная ошибка'}`;
+    }
     logError('Signup failed', error);
   } finally {
     isLoading.value = false;

--- a/supabase/functions/create-project/index.ts
+++ b/supabase/functions/create-project/index.ts
@@ -3,45 +3,48 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { corsHeaders } from '../_shared/cors.ts';
 
 Deno.serve(async (req) => {
+  // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders, status: 200 });
   }
 
   try {
-    const supabaseAdmin = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
-    );
-
     const { name, description, workspace_id } = await req.json();
 
-    // Auth check
+    // Auth check: Ensure the user has sent an Authorization header
     const authHeader = req.headers.get('Authorization');
     if (!authHeader) {
-      throw new Error('Missing Authorization header');
-    }
-    const { data: { user }, error: userError } = await supabaseAdmin.auth.getUser(authHeader.replace('Bearer ', ''));
-
-    if (userError || !user) {
-      console.error('Auth error:', userError);
-      return new Response(JSON.stringify({ error: 'Authentication failed' }), {
+      // This is a critical client-side error.
+      return new Response(JSON.stringify({ error: 'Missing Authorization header' }), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         status: 401,
       });
     }
 
-    const { data: project, error: projectError } = await supabaseAdmin
+    // Create a user-specific Supabase client by forwarding the Authorization header.
+    // This allows the RLS policies and database defaults (like `auth.uid()`) to work correctly.
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      { global: { headers: { Authorization: authHeader } } }
+    );
+
+    // Insert the new project. The `created_by` field is now omitted,
+    // as it will be automatically set by the database `DEFAULT auth.uid()`.
+    const { data: project, error: projectError } = await supabase
       .from('projects')
-      .insert({ name, description, workspace_id, created_by: user.id })
+      .insert({ name, description, workspace_id }) // `created_by` is removed
       .select()
       .single();
 
     if (projectError) {
+      // If there's an error during insertion (e.g., RLS violation), throw it.
       console.error('Project creation error:', projectError);
-      // The trigger will handle adding the user to project_members.
-      // No need for that logic here.
       throw projectError;
     }
+
+    // The `on_project_created_assign_owner` trigger will automatically handle
+    // adding the user to the `project_members` table.
 
     return new Response(JSON.stringify(project), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
@@ -51,7 +54,7 @@ Deno.serve(async (req) => {
     console.error('Error in create-project:', error);
     return new Response(JSON.stringify({ error: error.message }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      status: 400, // Using 400 for client-side errors, but could be 500 for internal ones
+      status: 400,
     });
   }
 });

--- a/supabase/migrations/006_add_created_by_to_projects.sql
+++ b/supabase/migrations/006_add_created_by_to_projects.sql
@@ -1,0 +1,9 @@
+-- File: supabase/migrations/006_add_created_by_to_projects.sql
+
+-- Add the created_by column to the projects table, with the default value
+-- set to the ID of the currently authenticated user. This ensures that the
+-- database, not the client, is the source of truth for project ownership.
+ALTER TABLE public.projects
+ADD COLUMN IF NOT EXISTS created_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL DEFAULT auth.uid();
+
+COMMENT ON COLUMN public.projects.created_by IS 'Автор проекта';


### PR DESCRIPTION
This commit addresses critical bugs related to project creation and user authentication, and improves the overall user experience.

- **fix(db):** Adds the `created_by` column to the `projects` table via a new migration. The column now defaults to `auth.uid()`, making the database the source of truth for project ownership and resolving the "column not found" error.

- **fix(auth):** Resolves the "Cannot read properties of null (reading 'auth')" error by ensuring a `.env.local` file is present for local development and confirming that `useAuth.js` has a defensive check against an uninitialized Supabase client.

- **refactor(functions):** The `create-project` Edge Function is refactored to use a user-level client, respecting RLS policies. It no longer manually sets `created_by`, relying on the new database default.

- **feat(ui):** The signup page (`Signup.vue`) now provides a clearer user experience by displaying a success message in Russian and automatically redirecting to the login page after registration.