### PR TITLE
fix: resolve db, auth, and ux issues

### DIFF
--- a/supabase/migrations/007_fix_project_owner_trigger.sql
+++ b/supabase/migrations/007_fix_project_owner_trigger.sql
@@ -1,0 +1,21 @@
+-- Migration: 007_fix_project_owner_trigger.sql
+-- Description: This migration updates the assign_project_owner function to fix a bug
+-- where the user_id was being inserted as NULL. The function now sources the user ID
+-- from the `created_by` column of the new project row.
+
+-- 1. Re-create the function with the corrected logic.
+-- This function now inserts a new row into project_members using the `created_by`
+-- field from the newly inserted project, which is correctly populated by a DEFAULT.
+CREATE OR REPLACE FUNCTION public.assign_project_owner()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Insert the creator of the project as the owner into the project_members table.
+  -- The user ID is now sourced from NEW.created_by instead of auth.uid(), which
+  -- was NULL in the trigger's security context.
+  INSERT INTO public.project_members (project_id, user_id, role)
+  VALUES (NEW.id, NEW.created_by, 'Owner');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.assign_project_owner IS 'Trigger function to automatically make the project creator an owner. Corrected to use NEW.created_by.';


### PR DESCRIPTION
This commit provides a comprehensive solution to several critical bugs, including the final fix for the project ownership trigger.

- **fix(db):** Adds a new migration (`007_...`) to correct the `assign_project_owner` trigger. The trigger now correctly sources the `user_id` from the `NEW.created_by` column of the `projects` table, resolving the `not-null constraint` violation.

- **fix(db):** Adds the `created_by` column to the `projects` table via migration `006_...`, with a `DEFAULT auth.uid()` value. This makes the database the source of truth for project ownership.

- **fix(auth):** Resolves the Supabase client initialization error by ensuring a `.env.local` file is present and that `useAuth.js` contains a defensive check.

- **refactor(functions):** The `create-project` Edge Function is refactored to use a user-level client, respecting RLS policies and relying on the database default for the `created_by` field.

- **feat(ui):** The signup page (`Signup.vue`) now provides a clearer user experience by displaying success and error messages in Russian and automatically redirecting to the login page after a successful registration.