### PR TITLE
fix: resolve issue with task type loading by passing projectId as a prop

### DIFF
--- a/npm_output.log
+++ b/npm_output.log
@@ -2,11 +2,8 @@
 > quantum-pm-platform@1.0.0 dev
 > vite
 
-Port 5173 is in use, trying another one...
-Port 5174 is in use, trying another one...
-Port 5175 is in use, trying another one...
 
-  VITE v4.5.14  ready in 881 ms
+  VITE v4.5.14  ready in 1387 ms
 
-  ➜  Local:   http://localhost:5176/
+  ➜  Local:   http://localhost:5173/
   ➜  Network: use --host to expose

--- a/src/components/TaskModal.vue
+++ b/src/components/TaskModal.vue
@@ -57,9 +57,13 @@
 import { ref, onMounted } from 'vue';
 import { getIssueTypes } from '../services/supabaseService.js';
 
+const props = defineProps({
+  projectId: {
+    type: String,
+    required: true,
+  },
+});
 const emit = defineEmits(['close', 'save']);
-const urlParams = new URLSearchParams(window.location.search);
-const projectId = urlParams.get('projectId');
 
 const task = ref({
   title: '',
@@ -72,8 +76,8 @@ const task = ref({
 const issueTypes = ref([]);
 
 onMounted(async () => {
-  if (projectId) {
-    issueTypes.value = await getIssueTypes(projectId);
+  if (props.projectId) {
+    issueTypes.value = await getIssueTypes(props.projectId);
     // Устанавливаем значение по умолчанию, только если типы задач существуют
     if (issueTypes.value.length > 0) {
       task.value.issue_type_id = issueTypes.value[0].id;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -28,7 +28,7 @@
       </div>
     </div>
     <!-- Modal for creating tasks -->
-    <TaskModal v-if="isCreateModalOpen" @close="isCreateModalOpen = false" @save="handleCreateTask" />
+    <TaskModal v-if="isCreateModalOpen" :project-id="projectId" @close="isCreateModalOpen = false" @save="handleCreateTask" />
     <!-- Modal for viewing task details -->
     <TaskDetailModal
       v-if="isDetailModalOpen"


### PR DESCRIPTION
This commit addresses a bug where the 'Тип задачи' (Issue Type) dropdown in the task creation modal would be stuck in a 'Загрузка...' (Loading...) state, preventing users from creating tasks.

The root cause was that the `TaskModal.vue` component was attempting to get the `projectId` from the URL query parameters. However, when the modal was opened, the `projectId` was not present in the URL, causing the call to `getIssueTypes` to fail with a `400 Bad Request` error.

The following changes have been made to resolve this:
- **Refactored `TaskModal.vue`**: The component no longer parses the `projectId` from the URL. Instead, it now accepts `projectId` as a required prop, making the component more robust and its data dependencies explicit.
- **Updated `Home.vue`**: The parent component, which renders the Kanban board and the task creation modal, has been updated to pass the `projectId` to `TaskModal.vue` via this new prop.

This ensures that the `TaskModal` always receives a valid `projectId` and can successfully fetch the issue types, resolving the bug.