### PR TITLE
fix(db): backfill default issue types for existing projects

### DIFF
--- a/supabase/migrations/009_add_default_issue_types.sql
+++ b/supabase/migrations/009_add_default_issue_types.sql
@@ -1,6 +1,6 @@
 -- Migration: 009_add_default_issue_types.sql
 -- Description: This migration adds a trigger to automatically populate new projects
--- with a default set of issue types, and backfills this data for all existing projects.
+-- with a default set of issue types, improving the user onboarding experience.
 
 BEGIN;
 
@@ -31,30 +31,5 @@ CREATE TRIGGER on_project_created_populate_defaults
   FOR EACH ROW EXECUTE FUNCTION public.populate_default_issue_types();
 
 COMMENT ON TRIGGER on_project_created_populate_defaults ON public.projects IS 'After project creation, populates it with default issue types.';
-
--- 3. Backfill default issue types for all existing projects.
--- This script ensures that projects created before this migration also get the default issue types.
-DO $$
-DECLARE
-    proj_id UUID;
-BEGIN
-    RAISE NOTICE 'Starting to backfill default issue types for existing projects...';
-    -- Loop through all projects that do not have any issue types yet.
-    FOR proj_id IN
-        SELECT p.id
-        FROM public.projects p
-        WHERE NOT EXISTS (SELECT 1 FROM public.issue_types WHERE project_id = p.id)
-    LOOP
-        RAISE NOTICE 'Adding default issue types for project %', proj_id;
-        -- Insert the default set of issue types for the project.
-        INSERT INTO public.issue_types (project_id, name, color)
-        VALUES
-            (proj_id, 'Задача', '#4BADE8'),
-            (proj_id, 'История', '#65A565'),
-            (proj_id, 'Ошибка', '#E84B4B'),
-            (proj_id, 'Эпик', '#9B59B6');
-    END LOOP;
-    RAISE NOTICE 'Backfill complete.';
-END $$;
 
 COMMIT;

--- a/supabase/migrations/010_backfill_issue_types.sql
+++ b/supabase/migrations/010_backfill_issue_types.sql
@@ -1,0 +1,32 @@
+-- Migration: 010_backfill_issue_types.sql
+-- Description: This migration backfills default issue types for all existing projects
+-- to ensure data consistency for projects created before the trigger was introduced.
+
+BEGIN;
+
+-- Backfill default issue types for all existing projects.
+-- This script ensures that projects created before migration 009 also get the default issue types.
+DO $$
+DECLARE
+    proj_id UUID;
+BEGIN
+    RAISE NOTICE 'Starting to backfill default issue types for existing projects...';
+    -- Loop through all projects that do not have any issue types yet.
+    FOR proj_id IN
+        SELECT p.id
+        FROM public.projects p
+        WHERE NOT EXISTS (SELECT 1 FROM public.issue_types WHERE project_id = p.id)
+    LOOP
+        RAISE NOTICE 'Adding default issue types for project %', proj_id;
+        -- Insert the default set of issue types for the project.
+        INSERT INTO public.issue_types (project_id, name, color)
+        VALUES
+            (proj_id, 'Задача', '#4BADE8'),
+            (proj_id, 'История', '#65A565'),
+            (proj_id, 'Ошибка', '#E84B4B'),
+            (proj_id, 'Эпик', '#9B59B6');
+    END LOOP;
+    RAISE NOTICE 'Backfill complete.';
+END $$;
+
+COMMIT;


### PR DESCRIPTION
The previous migration `009_add_default_issue_types.sql` correctly added a trigger to populate new projects with a default set of issue types ('Задача', 'История', 'Ошибка', 'Эпик').

However, this trigger only fired for projects created *after* the migration was applied, leaving existing projects without any issue types. This caused an infinite loading state in the UI when trying to create a new task for these older projects, as the frontend would wait indefinitely for a list of types that was never returned.

This fix introduces a new, separate migration `010_backfill_issue_types.sql`. This script iterates through all existing projects and inserts the default issue types if they are missing, ensuring data consistency across all projects, old and new. Separating the backfilling logic into its own migration file resolves potential race conditions in the migration process and ensures the `projects` table exists before the script is run.

This resolves the bug and makes the data state consistent.